### PR TITLE
replay integration: fix initialisation of integration

### DIFF
--- a/view/frontend/templates/script/sentry.phtml
+++ b/view/frontend/templates/script/sentry.phtml
@@ -40,7 +40,7 @@ if (typeof Sentry !== 'undefined') {
             }),
             <?php endif ?>
             <?php if ($block->useSessionReplay()): ?>
-            new Sentry.Replay({
+            Sentry.replayIntegration({
                 blockAllMedia: <?= $block->escapeHtml($block->getReplayBlockMedia() ? 'true' : 'false') ?>,
                 maskAllText: <?= $block->escapeHtml($block->getReplayMaskText() ? 'true' : 'false') ?>,
             })


### PR DESCRIPTION
`new Sentry.Replay` does not work anymore with the latest javsascript sdk. 

it has been replaced with `Sentry.replayIntegration`